### PR TITLE
Allow also version 4 of symfony/yaml package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
       }
     ],
     "require": {
-        "symfony/yaml": "^3.4"
+        "symfony/yaml": "^3.4|^4.0"
     },
     "autoload": {
         "psr-4": {"Amazee\\LaragoonSupport\\": "src/"}


### PR DESCRIPTION
When there is no compatibility issue, would be grate also to allow version 4 of the symfony/yaml package.